### PR TITLE
feat: agregar vista inicial para historial

### DIFF
--- a/lib/components/home/side_bar.dart
+++ b/lib/components/home/side_bar.dart
@@ -1,4 +1,5 @@
 import 'package:churrys_waffles/views/add_order_page.dart';
+import 'package:churrys_waffles/views/history.dart';
 import 'package:churrys_waffles/views/home.dart';
 import 'package:flutter/material.dart';
 
@@ -25,6 +26,13 @@ class SideBar extends StatelessWidget {
           title: Text('Add Order'),
           onTap: () => {
             Navigator.of(context).pushNamed(AddOrderPage.id),
+          },
+        ),
+        ListTile(
+          leading: const Icon(Icons.history),
+          title: const Text('History'),
+          onTap: () => {
+            Navigator.of(context).pushNamed(History.id),
           },
         ),
         ListTile(

--- a/lib/utils/route_generator.dart
+++ b/lib/utils/route_generator.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../views/home.dart';
 import '../views/add_order_page.dart';
+import '../views/history.dart';
 
 class RouteGenerator {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -12,6 +13,8 @@ class RouteGenerator {
         return MaterialPageRoute(builder: (_) => MyHomePage());
       case AddOrderPage.id:
         return MaterialPageRoute(builder: (_) => AddOrderPage());
+      case History.id:
+        return MaterialPageRoute(builder: (_) => const History());
       // Validation of correct data type
       /*       if (args is String) {
           return MaterialPageRoute(

--- a/lib/views/history.dart
+++ b/lib/views/history.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+class History extends StatefulWidget {
+  static const String id = '/history';
+
+  const History({Key? key}) : super(key: key);
+  @override
+  State<History> createState() => _HistoryState();
+}
+
+class _HistoryState extends State<History> {
+
+  final orders = [
+    {
+        "name": "wafle 1",
+        "direction": "avenida mata",
+        "date": "01/01/2021",
+        "paid_type": "transferencia"
+    },
+    {
+        "name": "wafle 2",
+        "direction": "avenida quilin",
+        "date": "01/01/2021",
+        "paid_type": "efectivo"
+    }
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('History'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ...(orders).map((order) {
+              return Text(order['name'] as String);
+            }).toList()
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Problema**:

Se necesita una vista para ver el historial de pedidos realizados, con un filtro para obtener información de interés.

**Solución:**

Crear un prototipo inicial de la vista.

**Pasos a seguir:**

1. Entrar al sidebar.
2. clickear "history"