### PR TITLE
feat: crear ordenes en memoria

### DIFF
--- a/lib/components/history/order_list.dart
+++ b/lib/components/history/order_list.dart
@@ -17,7 +17,8 @@ class _OrderListState extends State<OrderList> {
         direction: 'Avenida Quilin',
         quantity: 4000,
         isPaid: false,
-        isDelivered: false)
+        isDelivered: false,
+        products: [])
   ];
 
   static const Map<bool, String> boolTranstalation = {

--- a/lib/components/home/order_list.dart
+++ b/lib/components/home/order_list.dart
@@ -22,7 +22,7 @@ class _OrderListState extends State<OrderList> with WidgetsBindingObserver {
   void didChangeDependencies() {
     final orders = Provider.of<Orders>(context);
     if (!orders.initListOrders) {
-      orders.fetchAndSetProducts();
+      orders.fetchAndSetOrders();
       orders.setinitListOrder(true);
     }
     super.didChangeDependencies();

--- a/lib/providers/order.dart
+++ b/lib/providers/order.dart
@@ -1,3 +1,4 @@
+import 'package:churrys_waffles/providers/product.dart';
 import 'package:flutter/foundation.dart';
 
 class Order with ChangeNotifier {
@@ -7,13 +8,16 @@ class Order with ChangeNotifier {
   int quantity;
   bool isPaid;
   bool isDelivered;
+  List<Product> products = [];
 
-  Order({
+  Order(
+    {
     required this.price,
     required this.paymentType,
     required this.direction,
     required this.quantity,
     required this.isPaid,
     required this.isDelivered,
+    required this.products, 
   });
 }

--- a/lib/providers/product.dart
+++ b/lib/providers/product.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/foundation.dart';
+
+class Product with ChangeNotifier {
+  String name;
+  int price;
+  int quantity;
+
+  Product({
+    required this.name,
+    required this.price,
+    required this.quantity,
+  });
+}

--- a/lib/views/add_order_page.dart
+++ b/lib/views/add_order_page.dart
@@ -1,6 +1,11 @@
+import 'package:churrys_waffles/providers/orders.dart';
 import 'package:flutter/material.dart';
 import '../components/commons/churrys_title.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../providers/order.dart';
+import '../../providers/product.dart';
+import 'package:provider/provider.dart';
 
 enum paymentType { E, T }
 
@@ -219,16 +224,25 @@ class _MyHomePageState extends State<AddOrderPage> {
   }
 
   void createNewOrder() async {
-    List<dynamic> productsInOrder = [];
+    List<Product> productsInOrder = [];
 
-    for (dynamic obj in productsData) {
-      if (obj["Quantity"] >= 1) {
-        productsInOrder.add(obj);
+    for (dynamic product in productsData) {
+      if (product["Quantity"] >= 1) {
+        productsInOrder.add(
+          Product(
+            name: product['Name'],
+            price: product['Price'],
+            quantity: product['Quantity'],
+          ),
+        );
       }
     }
     if (extraQuantity >= 1) {
-      productsInOrder.add(
-          {'Name': 'Extra', 'Price': extraPrice, 'Quantity': extraQuantity});
+      productsInOrder.add(Product(
+        name: 'Extra',
+        price: extraPrice,
+        quantity: extraQuantity,
+      ));
     }
     String paymentTypeConverted = '';
     if (paymentFlow == paymentType.E) {
@@ -237,16 +251,16 @@ class _MyHomePageState extends State<AddOrderPage> {
       paymentTypeConverted = 'T';
     }
 
-    await _collectionRefOrders.add({
-      'Price': newOrder["TotalPrice"],
-      'Quantity': newOrder["TotalQuantity"],
-      'Direction': direction,
-      'PaymentType': paymentTypeConverted,
-      'Products': productsInOrder,
-      'isPaid': false,
-      'isDelivered': false
-    });
+    final order = Order(
+        price: newOrder["TotalPrice"],
+        paymentType: paymentTypeConverted,
+        direction: direction,
+        quantity: newOrder["TotalQuantity"],
+        isPaid: false,
+        isDelivered: false,
+        products: productsInOrder);
 
+    Provider.of<Orders>(context, listen: false).addOrder(order);
   }
 }
 


### PR DESCRIPTION
**Problema**:

1. Se necesita crear una orden sin necesidad de volver a traer las ordenes de firebase.
2. Se necesita una interfaz común para la creación de productos, para que puedan ser guardados correctamente dentro de una orden.


**Solución:**

1. Agregar a la lista de ordenes la nueva orden sin hacer un fetch a la db.
2. Creación del nuevo modelo "Product".

***Imágenes:*

*cambio en back*

**Pasos a seguir:**

1. Crear un producto.
2. Colocar algún print en "fetchAndSetOrders" y verficar que no sea llamado de nuevo luego de crear un nuevo producto.