### PR TITLE
feat: creación de filtro y agregar fecha de creación

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "churryswafflesapp",
+            "program": "lib/main.dart",
+            "request": "launch",
+            "type": "dart",
+            "args": [
+                "--no-sound-null-safety"
+            ]
+        }
+    ]
+}

--- a/lib/components/commons/order_item.dart
+++ b/lib/components/commons/order_item.dart
@@ -51,6 +51,17 @@ class _OrderItemState extends State<OrderItem> {
           },
         ),
       );
+      buttons.add(
+        ElevatedButton(
+          child: const Text('Eliminar'),
+          autofocus: false,
+          onPressed: () {
+            buildOverlayCircularProgress(context);
+            Provider.of<Orders>(context, listen: false)
+                .deleteOrder(widget.order);
+          },
+        ),
+      );
     }
 
     if (order.isPaid && !order.isDelivered) {
@@ -84,6 +95,18 @@ class _OrderItemState extends State<OrderItem> {
           },
         ),
       );
+
+      buttons.add(
+        ElevatedButton(
+          child: const Text('Eliminar'),
+          autofocus: false,
+          onPressed: () {
+            buildOverlayCircularProgress(context);
+            Provider.of<Orders>(context, listen: false)
+                .deleteOrder(widget.order);
+          },
+        ),
+      );
     }
 
     if (order.isPaid && order.isDelivered) {
@@ -103,17 +126,6 @@ class _OrderItemState extends State<OrderItem> {
         ),
       );
     }
-
-    buttons.add(
-      ElevatedButton(
-        child: const Text('Eliminar'),
-        autofocus: false,
-        onPressed: () {
-          buildOverlayCircularProgress(context);
-          Provider.of<Orders>(context, listen: false).deleteOrder(widget.order);
-        },
-      ),
-    );
 
     return buttons;
   }
@@ -142,7 +154,7 @@ class _OrderItemState extends State<OrderItem> {
               style: const TextStyle(fontSize: 18),
             ),
             subtitle: Text(
-                'Tipo de Pago: ${Order.paymentTypes[widget.order.paymentType]}\nCantidad de Productos: ${widget.order.quantity}\nPrecio: \$ ${widget.order.price}'),
+                'Fecha de Orden: ${DateFormat('dd/MM hh:mm').format(widget.order.createdAt)}\nTipo de Pago: ${Order.paymentTypes[widget.order.paymentType]}\nCantidad de Productos: ${widget.order.quantity}\nPrecio: \$ ${widget.order.price}'),
             trailing: Icon(
               _expanded ? Icons.expand_less : Icons.expand_more,
               size: 40,

--- a/lib/components/home/side_bar.dart
+++ b/lib/components/home/side_bar.dart
@@ -1,8 +1,11 @@
+import 'package:churrys_waffles/providers/orders.dart';
 import 'package:churrys_waffles/views/add_order_page.dart';
 import 'package:churrys_waffles/views/history.dart';
 import 'package:churrys_waffles/views/home.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+// ignore: use_key_in_widget_constructors
 class SideBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -15,15 +18,15 @@ class SideBar extends StatelessWidget {
           ),
         ),
         ListTile(
-          leading: Icon(Icons.home),
-          title: Text('Home'),
+          leading: const Icon(Icons.home),
+          title: const Text('Home'),
           onTap: () => {
             Navigator.of(context).pushNamed(MyHomePage.id),
           },
         ),
         ListTile(
-          leading: Icon(Icons.add_shopping_cart),
-          title: Text('Add Order'),
+          leading: const Icon(Icons.add_shopping_cart),
+          title: const Text('Add Order'),
           onTap: () => {
             Navigator.of(context).pushNamed(AddOrderPage.id),
           },
@@ -32,12 +35,15 @@ class SideBar extends StatelessWidget {
           leading: const Icon(Icons.history),
           title: const Text('History'),
           onTap: () => {
-            Navigator.of(context).pushNamed(History.id),
+            Provider.of<Orders>(context, listen: false).setFilters({}),
+            Provider.of<Orders>(context, listen: false)
+                .setinitListHistoryOrders(false),
+            Navigator.of(context).pushNamed(History.id)
           },
         ),
         ListTile(
-          leading: Icon(Icons.home),
-          title: Text('Report'),
+          leading: const Icon(Icons.home),
+          title: const Text('Report'),
           onTap: () => {
             // Navigator.of(context).pushNamed(),
           },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import '../providers/products.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
@@ -18,7 +19,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (ctx) => Orders())
+        ChangeNotifierProvider(create: (ctx) => Orders()),
+        ChangeNotifierProvider(create: (ctx) => Products())
       ],
       child: MaterialApp(
         title: 'Churry\'s Waffles App',

--- a/lib/providers/order.dart
+++ b/lib/providers/order.dart
@@ -1,5 +1,6 @@
 import 'package:churrys_waffles/providers/product.dart';
 import 'package:churrys_waffles/views/add_order_page.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 
 class Order with ChangeNotifier {
@@ -11,6 +12,7 @@ class Order with ChangeNotifier {
   bool isPaid;
   bool isDelivered;
   List<Product> products = [];
+  DateTime createdAt;
 
   Order({
     required this.id,
@@ -21,6 +23,7 @@ class Order with ChangeNotifier {
     required this.isPaid,
     required this.isDelivered,
     required this.products,
+    required this.createdAt,
   });
 
   static get paymentTypes {

--- a/lib/providers/orders.dart
+++ b/lib/providers/orders.dart
@@ -7,6 +7,8 @@ import './order.dart';
 class Orders with ChangeNotifier {
   List<Order> _orders = [];
   bool _initListOrders = false;
+  bool _initListHistoryOrders = false;
+  Map<String, dynamic> _filter = {};
 
   List<Order> get orders {
     return [..._orders];
@@ -20,24 +22,46 @@ class Orders with ChangeNotifier {
     _initListOrders = status;
   }
 
+  bool get initListHistoryOrders {
+    return _initListHistoryOrders;
+  }
+
+  void setinitListHistoryOrders(bool status) {
+    _initListHistoryOrders = status;
+  }
+
+  Map<String, dynamic> get filters {
+    return _filter;
+  }
+
+  void setFilters(Map<String, dynamic> filters) {
+    _filter = filters;
+  }
+
   List<Order> get newOrders {
-    return _orders.where(
+    final orders = _orders.where(
       (order) {
         return (!order.isDelivered && !order.isPaid);
       },
     ).toList();
+    orders.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return orders;
   }
 
   List<Order> get paidOrders {
-    return _orders.where((order) {
+    final orders = _orders.where((order) {
       return (!order.isDelivered && order.isPaid);
     }).toList();
+    orders.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return orders;
   }
 
   List<Order> get deliveredOrders {
-    return _orders.where((order) {
+    final orders = _orders.where((order) {
       return (order.isDelivered && order.isPaid);
     }).toList();
+    orders.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return orders;
   }
 
   Future<void> setStatusOrder(
@@ -57,9 +81,11 @@ class Orders with ChangeNotifier {
       direction: existingProduct.direction,
       quantity: existingProduct.quantity,
       products: existingProduct.products,
+      createdAt: existingProduct.createdAt,
       isDelivered: isDelivered,
       isPaid: isPaid,
     );
+    setinitListHistoryOrders(false);
     notifyListeners();
   }
 
@@ -84,6 +110,7 @@ class Orders with ChangeNotifier {
         isDelivered: order.get('isDelivered'),
         price: order.get('Price'),
         products: products,
+        createdAt: DateTime.parse(order.get('CreatedAt').toDate().toString()),
       );
     }).toList();
     _orders = orders;
@@ -107,7 +134,8 @@ class Orders with ChangeNotifier {
               })
           .toList(),
       'isPaid': false,
-      'isDelivered': false
+      'isDelivered': false,
+      'CreatedAt': newOrder.createdAt,
     }).then((doc) {
       newOrder.id = doc.id;
     });

--- a/lib/providers/products.dart
+++ b/lib/providers/products.dart
@@ -1,0 +1,35 @@
+import 'package:churrys_waffles/providers/product.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+class Products with ChangeNotifier {
+  List<Product> _products = [];
+  bool _initListproducts = false;
+
+  List<Product> get products {
+    return [..._products];
+  }
+
+  bool get initListproducts {
+    return _initListproducts;
+  }
+
+  void setinitListproduct(bool status) {
+    _initListproducts = status;
+  }
+
+  Future<void> fetchAndSetProducts() async {
+    final CollectionReference collectionRefOrders =
+        FirebaseFirestore.instance.collection('products');
+    QuerySnapshot querySnapshot = await collectionRefOrders.get();
+    final products = querySnapshot.docs.map((product) {
+      return Product(
+        name: product.get('Name'),
+        price: product.get('Price'),
+        quantity: product.get('Price'),
+      );
+    }).toList();
+    _products = products;
+    notifyListeners();
+  }
+}

--- a/lib/views/add_order_page.dart
+++ b/lib/views/add_order_page.dart
@@ -253,14 +253,16 @@ class _MyHomePageState extends State<AddOrderPage> {
     }
 
     final order = Order(
-        id: '',
-        price: newOrder["TotalPrice"],
-        paymentType: paymentTypeConverted,
-        direction: direction,
-        quantity: newOrder["TotalQuantity"],
-        isPaid: false,
-        isDelivered: false,
-        products: productsInOrder);
+      id: '',
+      price: newOrder["TotalPrice"],
+      paymentType: paymentTypeConverted,
+      direction: direction,
+      quantity: newOrder["TotalQuantity"],
+      isPaid: false,
+      isDelivered: false,
+      products: productsInOrder,
+      createdAt: DateTime.now(),
+    );
 
     Provider.of<Orders>(context, listen: false).addOrder(order);
   }

--- a/lib/views/history.dart
+++ b/lib/views/history.dart
@@ -1,40 +1,315 @@
+import 'dart:async';
+
+import 'package:churrys_waffles/providers/order.dart';
+import 'package:churrys_waffles/providers/products.dart';
+import 'package:churrys_waffles/views/add_order_page.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:smart_select/smart_select.dart';
 
 import '../providers/orders.dart';
 import '../components/commons/order_list.dart';
 
 class History extends StatefulWidget {
   static const String id = '/history';
+  final String? restorationId;
 
-  const History({Key? key}) : super(key: key);
+  const History({Key? key, this.restorationId}) : super(key: key);
   @override
   State<History> createState() => _HistoryState();
 }
 
-class _HistoryState extends State<History> {
+class _HistoryState extends State<History> with RestorationMixin {
+  List<Order> filteredOrders = [];
+  final _directionController = TextEditingController();
+  var _productSelection = '';
+  var _paymentTypeSelection = '';
+  RestorableDateTimeN _startDate = RestorableDateTimeN(DateTime(2022, 1, 1));
+  RestorableDateTimeN _endDate = RestorableDateTimeN(DateTime(2022, 1, 5));
+
+  @override
+  String? get restorationId => widget.restorationId;
+
+  @override
+  void didChangeDependencies() {
+    final orders = Provider.of<Orders>(context);
+    final isInit = orders.initListHistoryOrders;
+    if (!isInit) {
+      setState(() {
+        filteredOrders = filteringData(orders.deliveredOrders, context);
+        _startDate = RestorableDateTimeN(filteredOrders.first.createdAt);
+        _endDate = RestorableDateTimeN(filteredOrders.last.createdAt);
+        orders.setinitListHistoryOrders(true);
+      });
+    }
+    super.didChangeDependencies();
+  }
+
+  late final RestorableRouteFuture<DateTimeRange?>
+      _restorableDateRangePickerRouteFuture =
+      RestorableRouteFuture<DateTimeRange?>(
+    onComplete: _selectDateRange,
+    onPresent: (NavigatorState navigator, Object? arguments) {
+      return navigator
+          .restorablePush(_dateRangePickerRoute, arguments: <String, dynamic>{
+        'initialStartDate': _startDate.value?.millisecondsSinceEpoch,
+        'initialEndDate': _endDate.value?.millisecondsSinceEpoch,
+      });
+    },
+  );
+
+  void _selectDateRange(DateTimeRange? newSelectedDate) {
+    if (newSelectedDate != null) {
+      setState(() {
+        _startDate.value = newSelectedDate.start;
+        _endDate.value = newSelectedDate.end;
+      });
+    }
+  }
+
+  @override
+  void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
+    registerForRestoration(_startDate, 'start_date');
+    registerForRestoration(_endDate, 'end_date');
+    registerForRestoration(
+        _restorableDateRangePickerRouteFuture, 'date_picker_route_future');
+  }
+
+  static Route<DateTimeRange?> _dateRangePickerRoute(
+    BuildContext context,
+    Object? arguments,
+  ) {
+    return DialogRoute<DateTimeRange?>(
+      context: context,
+      builder: (BuildContext context) {
+        return DateRangePickerDialog(
+          fieldStartHintText: 'Seleccione una fecha',
+          fieldEndHintText: 'Selecciones una fecha',
+          fieldStartLabelText: 'Inicio',
+          fieldEndLabelText: 'Fin',
+          saveText: 'Guardar',
+          helpText: 'Seleccionar Fecha',
+          confirmText: 'Confirmar',
+          cancelText: 'Cancelar',
+          restorationId: 'date_picker_dialog',
+          initialDateRange:
+              _initialDateTimeRange(arguments! as Map<dynamic, dynamic>),
+          firstDate: DateTime(2022, 1, 1),
+          currentDate: DateTime(2022, 6, 15),
+          lastDate: DateTime(2030),
+        );
+      },
+    );
+  }
+
+  static DateTimeRange? _initialDateTimeRange(Map<dynamic, dynamic> arguments) {
+    if (arguments['initialStartDate'] != null &&
+        arguments['initialEndDate'] != null) {
+      return DateTimeRange(
+        start: DateTime.fromMillisecondsSinceEpoch(
+            arguments['initialStartDate'] as int),
+        end: DateTime.fromMillisecondsSinceEpoch(
+            arguments['initialEndDate'] as int),
+      );
+    }
+
+    return null;
+  }
+
+  void setCurrentFilter() {
+    Provider.of<Orders>(context, listen: false).setFilters({
+      "direction": _directionController.text.toLowerCase(),
+      "product": _productSelection,
+      "paymentType": _paymentTypeSelection.toLowerCase(),
+      "startDate": _startDate.value,
+      "endDate": _endDate.value,
+    });
+  }
+
+  List<Order> filteringData(
+      List<Order> iniFilteredOrders, BuildContext context) {
+    final filters = Provider.of<Orders>(context, listen: false).filters;
+    if (filters.isEmpty) {
+      return iniFilteredOrders;
+    } else {
+      final direction = filters["direction"];
+      final product = filters["product"];
+      final paymentType = filters["paymentType"];
+      final startDate = filters["startDate"];
+      final endDate = filters["endDate"];
+      final orders = iniFilteredOrders.where((order) {
+        if (direction != '' &&
+            !order.direction.toLowerCase().contains(direction)) {
+          return false;
+        }
+
+        if (product != '' &&
+            !order.products
+                .map((product) => product.name)
+                .toList()
+                .contains(product)) {
+          return false;
+        }
+
+        if (paymentType != '' &&
+            !order.paymentType.toLowerCase().contains(paymentType)) {
+          return false;
+        }
+        if (order.createdAt.isBefore(startDate) ||
+            order.createdAt.isAfter(endDate.add(const Duration(hours: 24)))) {
+          return false;
+        }
+
+        return true;
+      }).toList();
+      return orders;
+    }
+  }
+
+  Future<void> buildOverlayCircularProgress(BuildContext context) async {
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        Future.delayed(const Duration(milliseconds: 300), () {
+          Navigator.of(context).pop(true);
+        });
+        return const Center(
+          child: CircularProgressIndicator(),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final products = Provider.of<Products>(context).products;
+
+    final AlertDialog dialog = AlertDialog(
+      title: const Text('Filtros'),
+      contentPadding: const EdgeInsets.all(10),
+      content: SizedBox(
+        height: 300,
+        child: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              const SizedBox(
+                height: 15,
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: TextField(
+                  decoration: const InputDecoration(labelText: 'Dirección'),
+                  controller: _directionController,
+                ),
+              ),
+              const SizedBox(
+                height: 15,
+              ),
+              SmartSelect<String>.single(
+                  placeholder: 'Selecciona',
+                  title: 'Producto',
+                  value: 'Producto',
+                  choiceItems: products
+                      .map((product) => S2Choice<String>(
+                          value: product.name, title: product.name))
+                      .toList(),
+                  onChange: (state) {
+                    _productSelection = state.value;
+                  }),
+              const SizedBox(
+                height: 15,
+              ),
+              SmartSelect<String>.single(
+                  placeholder: 'Selecciona',
+                  title: 'Tipo de Pago',
+                  value: 'Tipo de Pago',
+                  choiceItems: [
+                    S2Choice<String>(value: 'E', title: 'Efectivo'),
+                    S2Choice<String>(value: 'T', title: 'Transferencia'),
+                  ],
+                  onChange: (state) {
+                    _paymentTypeSelection = state.value;
+                  }),
+              const SizedBox(
+                height: 15,
+              ),
+              OutlinedButton(
+                onPressed: () {
+                  _restorableDateRangePickerRouteFuture.present();
+                },
+                child: const Text('Seleccionar Rango de Fecha'),
+              )
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          style: ButtonStyle(
+              foregroundColor:
+                  MaterialStateProperty.resolveWith((_) => Colors.black),
+              backgroundColor:
+                  MaterialStateProperty.resolveWith((_) => Colors.red)),
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancelar'),
+        ),
+        TextButton(
+          style: ButtonStyle(
+              foregroundColor:
+                  MaterialStateProperty.resolveWith((_) => Colors.black),
+              backgroundColor:
+                  MaterialStateProperty.resolveWith((_) => Colors.green)),
+          onPressed: () {
+            setCurrentFilter();
+            final orders = filteringData(
+                Provider.of<Orders>(context, listen: false).deliveredOrders,
+                context);
+            setState(() {
+              filteredOrders = orders;
+            });
+            Navigator.pop(context);
+            buildOverlayCircularProgress(context);
+          },
+          child: const Text('Aceptar'),
+        ),
+      ],
+    );
+
     return Scaffold(
         appBar: AppBar(
           title: const Text('History'),
+        ),
+        floatingActionButton: FloatingActionButton(
+          child: const Icon(Icons.filter_list_rounded),
+          onPressed: () {
+            setState(() {
+              _directionController.clear();
+              _productSelection = '';
+              _paymentTypeSelection = '';
+            });
+            showDialog(builder: (context) => dialog, context: context);
+          },
         ),
         body: SingleChildScrollView(
           scrollDirection: Axis.vertical,
           child: Column(
             children: [
-              Container(
-                padding: const EdgeInsets.only(top: 25),
-                child: Title(
-                  color: Colors.black,
-                  child: const Text(
-                    'Historial de Pedidos',
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              Center(
+                child: Container(
+                  padding: const EdgeInsets.only(top: 25),
+                  child: Title(
+                    color: Colors.black,
+                    child: const Text(
+                      'Historial de Pedidos',
+                      style:
+                          TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                    ),
                   ),
                 ),
               ),
               OrderList(
-                orders: Provider.of<Orders>(context).deliveredOrders,
+                orders: filteredOrders,
               ),
             ],
           ),

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -1,3 +1,4 @@
+import 'package:churrys_waffles/providers/products.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:provider/provider.dart';
@@ -14,31 +15,18 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  // final CollectionReference _collectionRef =
-  //     FirebaseFirestore.instance.collection('products');
-
-  // Future<void> getData() async {
-  //   // Get docs from collection reference
-  //   QuerySnapshot querySnapshot = await _collectionRef.get();
-  //
-  //   // Get data from docs and convert map to List
-  //   final allData = querySnapshot.docs.map((doc) => doc.data()).toList();
-  //   print('se ejecuta el getData');
-  //   print(allData);
-  // }
-
-  // @override
-  // void initState() {
-  //   // Provider.of<Orders>(context).fetchAndSetProducts;
-  //   super.initState();
-  // }
 
   @override
   void didChangeDependencies() {
     final orders = Provider.of<Orders>(context);
+    final products = Provider.of<Products>(context);
     if (!orders.initListOrders) {
       orders.fetchAndSetOrders();
       orders.setinitListOrder(true);
+    }
+    if (!products.initListproducts) {
+      products.fetchAndSetProducts();
+      products.setinitListproduct(true);
     }
     super.didChangeDependencies();
   }
@@ -59,26 +47,30 @@ class _MyHomePageState extends State<MyHomePage> {
           scrollDirection: Axis.vertical,
           child: Column(
             children: [
-              Container(
-                padding: const EdgeInsets.only(top: 25),
-                child: Title(
-                  color: Colors.black,
-                  child: const Text(
-                    'Pedidos Nuevos - Confirmación de Pago',
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              Center(
+                child: Container(
+                  padding: const EdgeInsets.only(top: 25),
+                  child: Title(
+                    color: Colors.black,
+                    child: const Text(
+                      'Pedidos Nuevos - Confirmación de Pago',
+                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                    ),
                   ),
                 ),
               ),
               OrderList(
                 orders: Provider.of<Orders>(context).newOrders,
               ),
-              Container(
-                padding: const EdgeInsets.only(top: 10),
-                child: Title(
-                  color: Colors.black,
-                  child: const Text(
-                    'Pedidos - Esperando Entrega',
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              Center(
+                child: Container(
+                  padding: const EdgeInsets.only(top: 10),
+                  child: Title(
+                    color: Colors.black,
+                    child: const Text(
+                      'Pedidos - Esperando Entrega',
+                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                    ),
                   ),
                 ),
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,6 +71,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  date_range_picker:
+    dependency: "direct dev"
+    description:
+      name: date_range_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -189,6 +196,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  smart_select:
+    dependency: "direct dev"
+    description:
+      name: smart_select
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.2"
   source_span:
     dependency: transitive
     description:
@@ -247,4 +261,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.16.0"
+  flutter: ">=1.17.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   provider: ^6.0.1
+  smart_select: ^4.3.2
+  date_range_picker: ^1.0.5
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
**Problema**:

1. Se necesita ordenar por fecha.
2. Se necesita filtrar data histórica por fecha, producto, dirección y tipo de pago.

**Solución:**

1. Incluir la fecha de creación a la hora de crear una orden.
1. Creación de un dialogo que permite el filtrado.

***Imágenes:***

history:

![image](https://user-images.githubusercontent.com/47183702/147860787-62d9a365-d1df-4805-ab59-859c65cdff9b.png)


**Pasos a seguir:**

1. Crear varias ordenes con distintos tipos de atributos.
2. Modificar fechas de estas ordenes directamente de firebase (para probar el filtro de fechas).
3. Ir a histórico y probar todas las combinaciones de filtros posibles.
4. Un comportamiento esperado es que cada vez que se salga de la vista de historia, todos los filtros desaparezcan.